### PR TITLE
Add support for TypeScript in script block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist
+/example/dist
 node_modules

--- a/example/build.js
+++ b/example/build.js
@@ -1,14 +1,18 @@
 (async function () {
+  const { resolve } = require("path");
   const result = await require("esbuild").build({
     bundle: true,
-    entryPoints: ["src/main.js"],
+    entryPoints: [resolve(__dirname, "src/main.js")],
     format: "esm",
     splitting: true,
-    minify: true,
-    external: ["vue"],
+    minify: false,
     plugins: [
-      require("../src/index.js")({ extractCss: true, production: true }),
+      require("../src/index.js")({
+        extractCss: true,
+        workers: false,
+        production: false,
+      }),
     ],
-    outdir: "dist",
+    outdir: resolve(__dirname, "dist"),
   });
 })();

--- a/example/index.html
+++ b/example/index.html
@@ -6,14 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ESBuild Vue Demo</title>
     <link rel="stylesheet" href="/dist/main.css" />
-    <script type="module">
-      import Vue from "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.esm.browser.js";
-      import App from "/dist/main.js";
-
-      new Vue({
-        render: (h) => h(App),
-      }).$mount("#root");
     </script>
+    <script type="module" src="/dist/main.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "esbuild": "^0.12.25",
     "http-server": "^13.0.1",
     "normalize.css": "^8.0.1",
+    "typescript": "^4.4.3",
     "vue": "2",
     "vue-template-compiler": "2"
   }

--- a/example/src/components/Message.vue
+++ b/example/src/components/Message.vue
@@ -1,11 +1,33 @@
 <template lang="pug">
-  .Message {{ uppercaseMsg }}
+  .Message 
+    span {{ uppercaseMsg }}
+    span {{ variant }}
 </template>
 <script lang="ts">
 import Vue from 'vue';
+import type { PropType } from 'vue'
 
+const variants = ['primary', 'secondary'] as const;
+
+/**
+ * ```html
+ * <script>
+ * export default Vue.extend({})
+ * <\/script> 
+ * ```
+ */
 export default Vue.extend({
-  props: ["msg"],
+  props: {
+    msg: {
+      type: String,
+      required: true
+    },
+    variant: {
+      type: String as PropType<typeof variants[number]>,
+      default: variants[0],
+      validator: (v: any) => variants.includes(v) 
+    }
+  },
   computed: {
     uppercaseMsg(): string {
       return this.msg.toUpperCase()

--- a/example/src/components/Message.vue
+++ b/example/src/components/Message.vue
@@ -1,10 +1,17 @@
-<template>
-  <p class="Message">{{ msg }}</p>
+<template lang="pug">
+  .Message {{ uppercaseMsg }}
 </template>
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
   props: ["msg"],
-};
+  computed: {
+    uppercaseMsg(): string {
+      return this.msg.toUpperCase()
+    }
+  }
+});
 </script>
 <style scoped>
 .Message {

--- a/example/src/main.js
+++ b/example/src/main.js
@@ -1,2 +1,7 @@
 import "./global.css";
-export { default } from "./App.vue";
+import Vue from "vue";
+import App from "./App.vue";
+
+new Vue({
+  render: (h) => h(App),
+}).$mount("#root");

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "esModuleInterop": true,
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.vue"]
+}

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -194,6 +194,11 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+
 union@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
   },
   "dependencies": {
     "@vue/component-compiler": "^4.2.4",
-    "lodash.escaperegexp": "^4.1.2",
     "@vue/component-compiler-utils": "^3.2.2",
+    "lodash.escaperegexp": "^4.1.2",
     "piscina": "^2.2.0",
-    "postcss": ">=6.0.0"
+    "postcss": ">=6.0.0",
+    "strip-comments": "^2.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@vue/component-compiler": "^4.2.4",
     "lodash.escaperegexp": "^4.1.2",
+    "@vue/component-compiler-utils": "^3.2.2",
     "piscina": "^2.2.0",
     "postcss": ">=6.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,7 @@ module.exports = function ({
       build.onLoad({ filter: /[^/]\.vue$/ }, async ({ path }) => {
         const filename = relative(process.cwd(), path);
         const source = await fs.promises.readFile(path, "utf8");
-
-        let { code, styles, errors, usedFiles } = await runTask({
+        let { code, styles, errors, usedFiles, scriptLoader } = await runTask({
           filename,
           source,
           extractCss,
@@ -61,8 +60,10 @@ module.exports = function ({
         if (errors && errors.length) {
           return { errors };
         }
-
-        return { contents: code };
+        return {
+          contents: code,
+          loader: scriptLoader,
+        };
       });
 
       if (extractCss) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -24,6 +24,7 @@ editModule("fs", (fs) => {
 });
 
 const componentCompiler = require("@vue/component-compiler");
+const { parse } = require("@vue/component-compiler-utils");
 
 module.exports = async ({
   filename,
@@ -43,7 +44,13 @@ module.exports = async ({
     }
     const result = compiler.compileToDescriptor(filename, source);
     let styles;
-
+    const { script } = parse({
+      source,
+      filename,
+      needMap: true,
+      compiler: require("vue-template-compiler"),
+    });
+    const scriptLoader = (script.attrs && script.attrs.lang) || "js";
     const resultErrors = combineErrors(result.template, ...result.styles);
     if (resultErrors.length > 0) {
       return { errors: resultErrors, usedFiles };
@@ -59,8 +66,7 @@ module.exports = async ({
     }
 
     const { code } = componentCompiler.assemble(compiler, source, result, {});
-
-    return { code, styles, usedFiles };
+    return { code, styles, usedFiles, scriptLoader };
   } catch (e) {
     return {
       errors: [

--- a/src/worker.js
+++ b/src/worker.js
@@ -25,6 +25,7 @@ editModule("fs", (fs) => {
 
 const componentCompiler = require("@vue/component-compiler");
 const { parse } = require("@vue/component-compiler-utils");
+const strip = require("strip-comments");
 
 module.exports = async ({
   filename,
@@ -50,6 +51,7 @@ module.exports = async ({
       needMap: true,
       compiler: require("vue-template-compiler"),
     });
+    result.script.code = strip(result.script.code);
     const scriptLoader = (script.attrs && script.attrs.lang) || "js";
     const resultErrors = combineErrors(result.template, ...result.styles);
     if (resultErrors.length > 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,23 +605,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vue/component-compiler-utils@^3.0.0":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.2.2.tgz#2f7ed5feed82ff7f0284acc11d525ee7eff22460"
-  integrity sha512-rAYMLmgMuqJFWAOb3Awjqqv5X3Q3hVr4jH/kgrFJpiU0j3a90tnNBplqbj+snzrgZhC9W128z+dtgMifOiMfJg==
-  dependencies:
-    consolidate "^0.15.1"
-    hash-sum "^1.0.2"
-    lru-cache "^4.1.2"
-    merge-source-map "^1.1.0"
-    postcss "^7.0.36"
-    postcss-selector-parser "^6.0.2"
-    source-map "~0.6.1"
-    vue-template-es2015-compiler "^1.9.0"
-  optionalDependencies:
-    prettier "^1.18.2"
-
-"@vue/component-compiler-utils@^3.2.2":
+"@vue/component-compiler-utils@^3.0.0", "@vue/component-compiler-utils@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.2.2.tgz#2f7ed5feed82ff7f0284acc11d525ee7eff22460"
   integrity sha512-rAYMLmgMuqJFWAOb3Awjqqv5X3Q3hVr4jH/kgrFJpiU0j3a90tnNBplqbj+snzrgZhC9W128z+dtgMifOiMfJg==
@@ -3221,15 +3205,6 @@ postcss@^7.0.36:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^7.0.36:
-  version "7.0.36"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
-  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -3801,6 +3776,11 @@ strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
+strip-comments@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-comments/-/strip-comments-2.0.1.tgz#4ad11c3fbcac177a67a40ac224ca339ca1c1ba9b"
+  integrity sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==
 
 strip-eof@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -621,6 +621,22 @@
   optionalDependencies:
     prettier "^1.18.2"
 
+"@vue/component-compiler-utils@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.2.2.tgz#2f7ed5feed82ff7f0284acc11d525ee7eff22460"
+  integrity sha512-rAYMLmgMuqJFWAOb3Awjqqv5X3Q3hVr4jH/kgrFJpiU0j3a90tnNBplqbj+snzrgZhC9W128z+dtgMifOiMfJg==
+  dependencies:
+    consolidate "^0.15.1"
+    hash-sum "^1.0.2"
+    lru-cache "^4.1.2"
+    merge-source-map "^1.1.0"
+    postcss "^7.0.36"
+    postcss-selector-parser "^6.0.2"
+    source-map "~0.6.1"
+    vue-template-es2015-compiler "^1.9.0"
+  optionalDependencies:
+    prettier "^1.18.2"
+
 "@vue/component-compiler@^4.2.4":
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler/-/component-compiler-4.2.4.tgz#db8c485c33b74c7d0e54c19a945f1a4cb65c9dc4"
@@ -3195,6 +3211,15 @@ postcss@^6.0.1:
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
+
+postcss@^7.0.36:
+  version "7.0.36"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
+  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
 
 postcss@^7.0.36:
   version "7.0.36"


### PR DESCRIPTION
Hi,

I've tested the plugin on a project using TypeScript in the script block (`<script lang="ts">`) and esbuild was complaining about TS specific syntax.

This PR adds support for TS by reading the `attrs.lang` attribute from the parsed SFC descriptors and sets the correct esbuild loader (js or ts). 

I had to use the `parse` function from `@vue/component-compiler-utils` because at the moment the language information is not exposed by `@vue/component-compiler` (see https://github.com/vuejs/vue-component-compiler/issues/113). The downside is that each module is parsed twice :disappointed: .

Another change that I made was using a module to strip all comments from the script source because the build wasn:' working with code like this:

```html
<script lang="ts">
import Vue from 'vue';
/**
 * ```html
 * <script>
 * export default Vue.extend({})
 * <\/script> 
 * ```
 */
export default Vue.extend({
  props: {
  }
  ...
```
</script>

Basically, the compiler was detecting two default exports. :thinking:  
