### PR TITLE
Expose vue-component-compiler assembleOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ The following options are available:
 - `onReadFile`: Will be called with the (non-normalized) paths of every file read during the compilation process. For example, external files included using `@import` declarations in `<style>` blocks.
 - `postcssPlugins`: PostCSS plugins which will be used when compiling `<style>` blocks in components.
 - `isAsync`: By default, components are compiled using the synchronous (non-async) compiler. If you use async PostCSS plugins, you need to specify `true` here.
+- `assembleOptions`: Allows to provide custom `normalizer`, `styleInjector` and `styleInjectorSSR` implementations ([upstream docs][vcc])
 
 [sfc]: https://vuejs.org/v2/guide/single-file-components.html
 [esbuild]: https://esbuild.github.io/
 [piscina]: https://www.npmjs.com/package/piscina
+[vcc]: https://github.com/vuejs/vue-component-compiler/tree/v4.2.4#handling-the-output

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following options are available:
 - `onReadFile`: Will be called with the (non-normalized) paths of every file read during the compilation process. For example, external files included using `@import` declarations in `<style>` blocks.
 - `postcssPlugins`: PostCSS plugins which will be used when compiling `<style>` blocks in components.
 - `isAsync`: By default, components are compiled using the synchronous (non-async) compiler. If you use async PostCSS plugins, you need to specify `true` here.
-- `assembleOptions`: Allows to provide custom `normalizer`, `styleInjector` and `styleInjectorSSR` implementations ([upstream docs][vcc])
+- `assembleOptions`: Allows to provide custom `normalizer`, `styleInjector` and `styleInjectorSSR` implementations ([upstream docs][vcc]).
 
 [sfc]: https://vuejs.org/v2/guide/single-file-components.html
 [esbuild]: https://esbuild.github.io/

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ module.exports = function ({
   onReadFile,
   postcssPlugins = [],
   isAsync = false,
+  assembleOptions = {},
 } = {}) {
   let runTask;
 
@@ -45,6 +46,7 @@ module.exports = function ({
           production,
           postcssPlugins,
           isAsync,
+          assembleOptions,
         });
 
         if (extractCss && styles && styles.length) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -41,6 +41,7 @@ module.exports = async ({
   production,
   postcssPlugins,
   isAsync,
+  assembleOptions,
 }) => {
   const compilerOptions = {
     template: {
@@ -76,7 +77,12 @@ module.exports = async ({
       }
     }
 
-    const { code } = componentCompiler.assemble(compiler, filename, result, {});
+    const { code } = componentCompiler.assemble(
+      compiler,
+      filename,
+      result,
+      assembleOptions
+    );
 
     return {
       code,

--- a/test/esbuild-vue.test.js
+++ b/test/esbuild-vue.test.js
@@ -15,6 +15,27 @@ test("expects importing Vue SFC to work", async () => {
   expect(src).toContain('__file = "test/input/MyComponent.vue"');
 });
 
+test("expects to allow custom normalizer", async () => {
+  const result = await require("esbuild").build({
+    bundle: true,
+    format: "esm",
+    external: ["custom-normalizer"],
+    entryPoints: ["test/input/main.js"],
+    plugins: [
+      require("../src/index.js")({
+        assembleOptions: { normalizer: "~custom-normalizer" },
+      }),
+    ],
+    write: false,
+  });
+
+  expect(result.outputFiles).toHaveLength(1);
+
+  const src = String.fromCodePoint(...result.outputFiles[0].contents);
+  expect(src).toContain('import __vue_normalize__ from "custom-normalizer"');
+  expect(src).toContain("Hello, World!");
+});
+
 test("expects CSS to be extracted", async () => {
   const result = await require("esbuild").build({
     bundle: true,


### PR DESCRIPTION
When using esbuild to compile a library of vue components, every
JavaScript version of a component ends up with a copy of
`__vue_normalize__`. The `vue-component-compiler` allows to define a
custom implementation [0]. Exposing this to the user allows for more
flexibility.

[0]: https://github.com/vuejs/vue-component-compiler/tree/v4.2.4#handling-the-output