### PR TITLE
Support   createCompilerOption

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ module.exports = function ({
   postcssPlugins = [],
   isAsync = false,
   assembleOptions = {},
+  createCompilerOption = {}
 } = {}) {
   let runTask;
 
@@ -47,6 +48,7 @@ module.exports = function ({
           postcssPlugins,
           isAsync,
           assembleOptions,
+          createCompilerOption,
         });
 
         if (extractCss && styles && styles.length) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -41,14 +41,20 @@ module.exports = async ({
   postcssPlugins,
   isAsync,
   assembleOptions,
+  createCompilerOption,
 }) => {
   const compilerOptions = {
     template: {
+      ...createCompilerOption.template,
       isProduction: production,
       compilerOptions: { outputSourceRange: true },
     },
     style: {
+      ...createCompilerOption.style,
       postcssPlugins,
+    },
+    script: {
+      ...createCompilerOption.script
     },
   };
   const compiler = componentCompiler.createDefaultCompiler(compilerOptions);


### PR DESCRIPTION
It should be supported, but may not be the default option.

For example, I need to use `optimizeSSR`

https://github.com/yisar/vkt/blob/main/packages/core/src/build.mjs#L22